### PR TITLE
A more complete and functional example

### DIFF
--- a/.environment
+++ b/.environment
@@ -1,0 +1,11 @@
+# Statements in this file will be executed (sourced) by the shell in SSH
+# sessions, in deploy hooks, in cron jobs, and in the application's runtime
+# environment.
+
+# Allow executable app dependencies from Composer to be run from the path.
+if [ -n "$PLATFORM_APP_DIR" -a -f "$PLATFORM_APP_DIR"/composer.json ] ; then
+  bin=$(composer config bin-dir --working-dir="$PLATFORM_APP_DIR" --no-interaction 2>/dev/null)
+  if [ -n "$bin" ] ; then
+    export PATH="${PLATFORM_APP_DIR}/${bin}:${PATH}"
+  fi
+fi

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -36,15 +36,21 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
-
+dependencies:
+  php:
+    wp-cli/wp-cli: "~0.22"
+    psy/psysh: "~0.6"
 # The mounts that will be performed when the package is deployed.
 mounts:
     "/wp/wp-content/uploads": "shared:files/uploads"
+    "/wp/wp-content/cache": "shared:files/cache"
 
 # The hooks that will be performed when the package is deployed.
 hooks:
     build: |
       mkdir -p wp/wp-content/themes
       mkdir -p wp/wp-content/plugins
+      mkdir -p wp/wp-content/languages
       cp -r plugins/* wp/wp-content/plugins/
       cp -r themes/* wp/wp-content/themes/
+      cp -r languages/* wp/wp-content/languages/

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -38,8 +38,8 @@ web:
 disk: 2048
 dependencies:
   php:
-    wp-cli/wp-cli: "~0.22"
-    psy/psysh: "~0.6"
+    wp-cli/wp-cli: "^1.1"
+    psy/psysh: "^0.8.4"
 # The mounts that will be performed when the package is deployed.
 mounts:
     "/wp/wp-content/uploads": "shared:files/uploads"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,12 @@
         "johnpbloch/wordpress": "~4.7"
     },
     "extra": {
-        "wordpress-install-dir": "wp"
+        "wordpress-install-dir": "wp",
+        "installer-paths": {
+            "wp/wp-content/plugins/{$name}": ["type:wordpress-plugin"],
+            "wp/wp-content/themes/{$name}": ["type:wordpress-theme"],
+            "wp/wp-content/mu-plugins/{$name}": ["type:wordpress-muplugin"]
+        }
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b76ec7b09b419897d5cf60c1ee786544",
-    "content-hash": "c1b318afbaa9d6bbe64122a5731004af",
+    "hash": "b861419116ef1c96805f8b361baefb0a",
+    "content-hash": "ee170dd19bc7bca5700e65e8715b216e",
     "packages": [
         {
             "name": "johnpbloch/wordpress",

--- a/languages/README.md
+++ b/languages/README.md
@@ -1,0 +1,2 @@
+Place translation files here The whole directory
+will be moved inside `wp/wp-content/languages/` at the end of the build process.

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+path: /app/wp/
+color: true

--- a/wp-config.php
+++ b/wp-config.php
@@ -9,6 +9,17 @@ if (empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
     // This is where we get the relationships of our application dynamically
     //from Platform.sh
 
+    // set session path to /tmp in cas we are using wp-cli to avoid notices
+    if (php_sapi_name() === 'cli') {
+      session_save_path("/tmp");
+    }
+
+    // we might be running wp-cli
+    if (isset($_SERVER['HTTP_HOST'])) {
+          $site_host = $_SERVER['HTTP_HOST'];
+          $site_scheme = !empty($_SERVER['https']) ? 'https' : 'http';
+    }
+
     $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
 
     // We are using the first relationship called "database" found in your
@@ -20,9 +31,6 @@ if (empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
     define('DB_HOST', $relationships['database'][0]['host']);
     define('DB_CHARSET', 'utf8');
     define('DB_COLLATE', '');
-
-    $site_host = $_SERVER['HTTP_HOST'];
-    $site_scheme = !empty($_SERVER['https']) ? 'https' : 'http';
 
     // Check whether a route is defined for this application in the Platform.sh routes.
     // Use it as the site hostname if so (it is not ideal to trust HTTP_HOST).


### PR DESCRIPTION
This adds:

* support for wp-cli so now you can run `platform ssh "wp"` to run commands directly on your installation.
* adds support for language files
* It also adds a missing writable directory for cache 
* sets correct installer paths

Tested on a real-world complex wordpress site but wasn't tested as installation from scratch.